### PR TITLE
[Feat/TK-177]: 세부 지출 내역 api 필드 수정

### DIFF
--- a/apps/mobile/app/travel/[id]/settlement/page.tsx
+++ b/apps/mobile/app/travel/[id]/settlement/page.tsx
@@ -33,8 +33,14 @@ export default async function Page({ params }: { params: Params }) {
     }
   }
 
-  const { myTotalPayment, disagreeCount, myDetailPayments, others } =
-    response.data as SettlementDetails;
+  const {
+    myTotalPayment,
+    disagreeCount,
+    totalPaymentAmounts,
+    totalRequestedAmounts,
+    myDetailPayments,
+    others,
+  } = response.data as SettlementDetails;
 
   return (
     <div className={styles.container}>
@@ -71,13 +77,13 @@ export default async function Page({ params }: { params: Params }) {
                 <span className={styles.label}>받을 금액 </span>
                 <span
                   className={styles.amount}
-                >{`${myTotalPayment.ownPaymentCost.toLocaleString()}원`}</span>
+                >{`${totalPaymentAmounts.toLocaleString()}원`}</span>
               </div>
               <div className={styles.summaryInfo}>
                 <span className={styles.label}>보낼 금액 </span>
                 <span
                   className={styles.amount}
-                >{`${myTotalPayment.actualBurdenCost.toLocaleString()}원`}</span>
+                >{`${totalRequestedAmounts.toLocaleString()}원`}</span>
               </div>
             </div>
 

--- a/apps/mobile/app/travel/[id]/settlement/page.tsx
+++ b/apps/mobile/app/travel/[id]/settlement/page.tsx
@@ -158,10 +158,10 @@ export default async function Page({ params }: { params: Params }) {
         <div className={styles.btnWrapper}>
           {myTotalPayment.agreed ? (
             <Button
-              label="정산 완료"
+              label="동의 완료"
               className={styles.disabledButton}
               disabled={true}
-              primary={false} // 정산 완료 상태일 경우 비활성화
+              primary={false} // 동의 완료 상태일 경우 비활성화
             />
           ) : (
             <Link href={{ pathname: `/travel/${params.id}/agreement` }}>

--- a/packages/apis/src/settlementService.ts
+++ b/packages/apis/src/settlementService.ts
@@ -6,8 +6,6 @@ import { ErrorResponse, SuccessResponse } from '@withbee/types';
 interface MyTotalPayment {
   name: string;
   totalPaymentCost: number;
-  ownPaymentCost: number;
-  actualBurdenCost: number;
   agreed: boolean;
 }
 
@@ -29,6 +27,8 @@ interface Other {
 export interface SettlementDetails {
   myTotalPayment: MyTotalPayment;
   disagreeCount: number;
+  totalPaymentAmounts: number;
+  totalRequestedAmounts: number;
   myDetailPayments: MyDetailPayment[];
   others: Other[];
 }


### PR DESCRIPTION
## 📋 연관된 이슈 번호

## 🛠 구현 사항

- 세부 지출 내역 조회 시 내가 결제했지만 정산 인원에 포함되지 않는 경우를 고려하도록 수정하도록 백엔드 로직을 수정했고, API 수정에 따라 settlementService.ts의 필드를 변경하였습니다. 

## 📚 변경 사항

## 🏜 스크린샷

- 세부 지출 내역 조회시
<img width="355" alt="image" src="https://github.com/user-attachments/assets/ebfecca9-badd-41bf-b136-76690656fda3">

- 받을 금액, 보낼 금액은 나의 세부 지출 내역 중 받을 금액의 합, 보낼 금액의 합으로 계산됩니다. 
- 내가 결제했지만 정산 인원에 포함되지 않는 경우는 결제 금액과 받을 금액이 동일하게 표시됩니다.   

## 💬 To Reviewers
