### PR TITLE
[feat/TK-165]: 직접 결제 내역 추가 페이지에 통화 코드 목록을 방문 국가의 통화 코드가 우선 뜨도록 구현

### DIFF
--- a/apps/mobile/app/travel/[id]/payments/layout.tsx
+++ b/apps/mobile/app/travel/[id]/payments/layout.tsx
@@ -9,13 +9,13 @@ interface LayoutProps {
   };
   children: React.ReactNode;
 }
-export default async function Layout({ children }: LayoutProps) {
+export default async function Layout({ params, children }: LayoutProps) {
   return (
     <>
       {/* // StoreInitializer로 서버에서 가져온 데이터를 클라이언트 스토어에 초기화 */}
       <main className={styles.container}>
         <Title label="공동 결제 내역" />
-        <Menu className={styles.menu} />
+        <Menu className={styles.menu} travelId={params.id} />
         <ItemGroup />
         {children}
       </main>

--- a/packages/apis/src/createManualSharedPayment.ts
+++ b/packages/apis/src/createManualSharedPayment.ts
@@ -1,6 +1,12 @@
+'use server';
+
 import { instance } from './instance';
 import { ManualPaymentFormData } from '../../ui/src/manual-shared-payment-form';
-import { SuccessResponse } from '@withbee/types';
+import {
+  SuccessResponse,
+  CurrencyUnitOptions,
+  ErrorResponse,
+} from '@withbee/types';
 
 export const createManualSharedPayment = async (
   travelId: string,
@@ -70,6 +76,17 @@ export const createManualSharedPayment = async (
       body: formDataToSend,
       isMultipart: true, // multipart/form-data로 전송
     },
+  );
+  return response;
+};
+
+export const getCurrencyUnitOptions = async (
+  travelId: string,
+): Promise<SuccessResponse<CurrencyUnitOptions> | ErrorResponse> => {
+  console.log('getCurrencyUnitOptions');
+
+  const response = await instance.get<CurrencyUnitOptions>(
+    `/api/travels/${travelId}/payments/currency-unit`,
   );
   return response;
 };

--- a/packages/apis/src/createManualSharedPayment.ts
+++ b/packages/apis/src/createManualSharedPayment.ts
@@ -83,8 +83,6 @@ export const createManualSharedPayment = async (
 export const getCurrencyUnitOptions = async (
   travelId: string,
 ): Promise<SuccessResponse<CurrencyUnitOptions> | ErrorResponse> => {
-  console.log('getCurrencyUnitOptions');
-
   const response = await instance.get<CurrencyUnitOptions>(
     `/api/travels/${travelId}/payments/currency-unit`,
   );

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,3 +5,4 @@ export type * from './travelType';
 export type * from './travelService';
 export type * from './authType';
 export type * from './bankingType';
+export type * from './manualSharedPayment';

--- a/packages/types/src/manualSharedPayment.ts
+++ b/packages/types/src/manualSharedPayment.ts
@@ -1,0 +1,3 @@
+export interface CurrencyUnitOptions {
+  currencyUnitOptions: string[];
+}

--- a/packages/ui/src/menu.tsx
+++ b/packages/ui/src/menu.tsx
@@ -11,10 +11,12 @@ import DatePickerModal from './date-picker-modal';
 import { usePaymentStore, useTravelStore } from '@withbee/stores';
 import { getDateObject } from '@withbee/utils';
 import { TravelMember } from '@withbee/types';
+import { useRouter } from 'next/navigation';
 
 interface MenuProps {
   // travelMembers: TravelMember[];
   className?: string;
+  travelId: string;
 }
 
 const AllMembers: TravelMember = {
@@ -23,7 +25,7 @@ const AllMembers: TravelMember = {
   profileImage: 0,
 };
 
-export const Menu = ({ className, ...props }: MenuProps) => {
+export const Menu = ({ className, travelId, ...props }: MenuProps) => {
   const {
     startDate,
     setStartDate,
@@ -83,6 +85,13 @@ export const Menu = ({ className, ...props }: MenuProps) => {
     // handleModal('member');
   };
 
+  const router = useRouter();
+
+  // 직접 결제 내역 추가 페이지 이동 핸들러
+  const handleRouteManualSharedPaymentPage = () => {
+    router.push(`/travel/${travelId}/manual`);
+  };
+
   return (
     <section className={[styles.menu, className].join(' ')} {...props}>
       <Image
@@ -118,7 +127,12 @@ export const Menu = ({ className, ...props }: MenuProps) => {
       ) : (
         <div className={styles.default}>
           <Button label="불러오기" size={'small'} />
-          <Button label="직접 추가" size={'small'} primary={false} />
+          <Button
+            label="직접 추가"
+            size={'small'}
+            primary={false}
+            onClick={handleRouteManualSharedPaymentPage}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## 📋 연관된 이슈 번호

- close #56 

## 🛠 구현 사항

- 직접 결제 내역 추가 페이지에 통화 코드 목록을 방문 국가의 통화 코드가 우선 뜨도록 구현

## 📚 변경 사항

- 직접 추가한 결제 내역 수정 기능은 변경해야할 것들이 너무 많아서 일단 보류하겠습니다ㅎㅎ

## 🏜 스크린샷

![image](https://github.com/user-attachments/assets/e2951175-8600-4afa-95e2-bc7a51457054)

## 💬 To Reviewers

- 전달할 사항들을 적어주세요.
